### PR TITLE
Fix gant risk panel status

### DIFF
--- a/dashboard/src/components/pmo_dashboard/AtRiskPanel.tsx
+++ b/dashboard/src/components/pmo_dashboard/AtRiskPanel.tsx
@@ -8,7 +8,7 @@ import {
   ShieldCheck,
   TrendingDown,
 } from 'lucide-react';
-import { UI_PROJECT_KEYS } from '../../constants/pmo_dashboard';
+import { AT_RISK_STATUS_KEYS, UI_PROJECT_KEYS } from '../../constants/pmo_dashboard';
 import { RiskReason, UIProjectRow } from '../../types/pmo_dashboard';
 
 type AtRiskPanelProps = {
@@ -25,6 +25,8 @@ const AtRiskPanel: React.FC<AtRiskPanelProps> = ({ data, onViewDetails }) => {
     today.setHours(0, 0, 0, 0);
 
     data.forEach((proj) => {
+      if (!AT_RISK_STATUS_KEYS.has(proj._statusKey || '')) return;
+
       const budget = proj[UI_PROJECT_KEYS.BUDGET_HOURS] ?? 0;
       const consumed = proj[UI_PROJECT_KEYS.CONSUMED_TIME] ?? 0;
       const totalCosting = proj[UI_PROJECT_KEYS.TOTAL_COSTING] ?? 0;
@@ -39,11 +41,6 @@ const AtRiskPanel: React.FC<AtRiskPanelProps> = ({ data, onViewDetails }) => {
       const budgetWarning = budget > 0 && consumed >= budget * 0.9;
       const costAtRisk = totalSales > 0 && totalCosting > totalSales * 0.9;
       const costWarning = totalSales > 0 && totalCosting >= totalSales * 0.7;
-
-      const isAtRisk = behindSchedule || overBudget || costAtRisk;
-      const isWarning = !isAtRisk && (budgetWarning || costWarning);
-
-      if (!isAtRisk && !isWarning) return;
 
       const reasons: RiskReason[] = [];
       if (behindSchedule) reasons.push({ type: 'schedule', text: 'Behind Schedule', icon: <Clock size={14} /> });

--- a/dashboard/src/components/pmo_dashboard/AtRiskPanel.tsx
+++ b/dashboard/src/components/pmo_dashboard/AtRiskPanel.tsx
@@ -4,12 +4,10 @@ import {
   ArrowRight,
   ChevronDown,
   ChevronUp,
-  Clock,
   ShieldCheck,
-  TrendingDown,
 } from 'lucide-react';
 import { AT_RISK_STATUS_KEYS, UI_PROJECT_KEYS } from '../../constants/pmo_dashboard';
-import { RiskReason, UIProjectRow } from '../../types/pmo_dashboard';
+import { UIProjectRow } from '../../types/pmo_dashboard';
 
 type AtRiskPanelProps = {
   data: UIProjectRow[];
@@ -19,41 +17,10 @@ type AtRiskPanelProps = {
 const AtRiskPanel: React.FC<AtRiskPanelProps> = ({ data, onViewDetails }) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const atRiskProjects = useMemo(() => {
-    const results: UIProjectRow[] = [];
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-
-    data.forEach((proj) => {
-      if (!AT_RISK_STATUS_KEYS.has(proj._statusKey || '')) return;
-
-      const budget = proj[UI_PROJECT_KEYS.BUDGET_HOURS] ?? 0;
-      const consumed = proj[UI_PROJECT_KEYS.CONSUMED_TIME] ?? 0;
-      const totalCosting = proj[UI_PROJECT_KEYS.TOTAL_COSTING] ?? 0;
-      const totalSales = proj[UI_PROJECT_KEYS.TOTAL_SALES_AMOUNT] ?? 0;
-
-      const dueDateStr = proj[UI_PROJECT_KEYS.DUE_DATE];
-      const dueDate = dueDateStr ? new Date(dueDateStr) : null;
-      if (dueDate) dueDate.setHours(0, 0, 0, 0);
-
-      const behindSchedule = dueDate !== null && dueDate < today;
-      const overBudget = budget > 0 && consumed > budget;
-      const budgetWarning = budget > 0 && consumed >= budget * 0.9;
-      const costAtRisk = totalSales > 0 && totalCosting > totalSales * 0.9;
-      const costWarning = totalSales > 0 && totalCosting >= totalSales * 0.7;
-
-      const reasons: RiskReason[] = [];
-      if (behindSchedule) reasons.push({ type: 'schedule', text: 'Behind Schedule', icon: <Clock size={14} /> });
-      if (overBudget) reasons.push({ type: 'budget', text: 'Budget Overrun', icon: <TrendingDown size={14} /> });
-      else if (budgetWarning) reasons.push({ type: 'budget', text: 'Budget at 90%+', icon: <AlertTriangle size={14} /> });
-      if (costAtRisk) reasons.push({ type: 'cost', text: 'Cost at 90%+', icon: <TrendingDown size={14} /> });
-      else if (costWarning) reasons.push({ type: 'cost', text: 'Cost at 70%+', icon: <AlertTriangle size={14} /> });
-
-      results.push({ ...proj, _riskReason: reasons });
-    });
-
-    return results;
-  }, [data]);
+  const atRiskProjects = useMemo(
+    () => data.filter((proj) => AT_RISK_STATUS_KEYS.has(proj._statusKey || '')),
+    [data],
+  );
 
   if (atRiskProjects.length === 0) {
     return (
@@ -110,9 +77,9 @@ const AtRiskPanel: React.FC<AtRiskPanelProps> = ({ data, onViewDetails }) => {
             </div>
 
             <div className='flex-1 flex flex-wrap gap-1.5 mb-4'>
-              {(proj._riskReason || []).map((reason, idx) => (
+              {(proj._statusReasons || []).map((reason, idx) => (
                 <div key={`${proj._id}-${idx}`} className='flex items-center gap-1.5 text-xs font-bold text-rose-600 dark:text-rose-400 bg-rose-50 dark:bg-rose-900/20 px-2 py-1 rounded-md w-fit'>
-                  {reason.icon} {reason.text}
+                  <AlertTriangle size={12} /> {reason}
                 </div>
               ))}
             </div>

--- a/dashboard/src/components/pmo_dashboard/EditableTable.tsx
+++ b/dashboard/src/components/pmo_dashboard/EditableTable.tsx
@@ -49,15 +49,15 @@ const EditableTable: React.FC<EditableTableProps> = ({
         <table className='w-full text-left border-collapse whitespace-normal break-words table-fixed'>
           <thead className='sticky top-0 z-20 shadow-sm'>
             <tr className='bg-slate-100/90 dark:bg-slate-800/90 backdrop-blur-sm text-slate-500 dark:text-slate-400 text-xs uppercase tracking-wider font-bold'>
-              <th className='px-4 py-3 w-[18%]'>Project</th>
+              <th className='px-4 py-3 w-[20%]'>Project</th>
               <th className='px-4 py-3 w-[10%]'>Project Manager</th>
               <th className='px-4 py-3 w-[9%]'>Due Date</th>
-              <th className='px-4 py-3 w-[10%]'>Status</th>
-              <th className='px-4 py-3 w-[9%] text-right'>Budget (Hrs)</th>
+              <th className='px-4 py-3 w-[8%]'>Status</th>
+              <th className='px-4 py-3 w-[8%] text-right'>Budget (Hrs)</th>
               <th className='px-4 py-3 w-[9%] text-right'>Consumed (Hrs)</th>
-              <th className='px-4 py-3 w-[11%] text-right'>Sales (ZAR)</th>
-              <th className='px-4 py-3 w-[11%] text-right'>Cost (ZAR)</th>
-              <th className='px-4 py-3 w-[9%] text-right'>Progress</th>
+              <th className='px-4 py-3 w-[13%] text-right'>Sales (ZAR)</th>
+              <th className='px-4 py-3 w-[13%] text-right'>Cost (ZAR)</th>
+              <th className='px-4 py-3 w-[6%] text-right'>Progress</th>
             </tr>
           </thead>
           <tbody className='divide-y divide-slate-100'>

--- a/dashboard/src/components/pmo_dashboard/EditableTable.tsx
+++ b/dashboard/src/components/pmo_dashboard/EditableTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PencilLine, Trash2 } from 'lucide-react';
-import { UI_PROJECT_KEYS } from '../../constants/pmo_dashboard';
+import { STATUS_KEY_BADGE, UI_PROJECT_KEYS } from '../../constants/pmo_dashboard';
 import { UIProjectRow } from '../../types/pmo_dashboard';
 import { formatManagerName } from '../../utils/pmo_dashboard';
 
@@ -86,21 +86,17 @@ const EditableTable: React.FC<EditableTableProps> = ({
                     className='w-full bg-transparent border-b border-transparent focus:border-indigo-400 focus:bg-white dark:focus:bg-slate-700 px-1 py-1 outline-none text-sm text-slate-600 dark:text-slate-300 transition-all font-medium'
                   />
                 </td>
-                <td className='px-4 py-3 align-top bg-white/50 dark:bg-slate-800/50 group-hover:bg-transparent'>
-                  <select
-                    value={row.Status || ''}
-                    onChange={(e) => handleChange(row._id, 'Status', e.target.value)}
-                    className='w-full bg-transparent border border-transparent hover:border-indigo-200 dark:hover:border-indigo-700 focus:border-indigo-400 focus:bg-white dark:focus:bg-slate-700 rounded-md px-1 py-1 outline-none text-sm text-slate-600 dark:text-slate-300 font-medium transition-all cursor-pointer'
-                  >
-                    <option value='' hidden>Select Status...</option>
-                    <option value='🟢 On track'>🟢 On track</option>
-                    <option value='🟡 Warning'>🟡 Warning</option>
-                    <option value='🟡 Delayed'>🟡 Delayed</option>
-                    <option value='🔴 At risk'>🔴 At risk</option>
-                    <option value='🔵 Overdue'>🔵 Overdue</option>
-                    <option value='⚪ On Hold'>⚪ On Hold</option>
-                    <option value='🟣 Completed'>🟣 Completed</option>
-                  </select>
+                <td className='px-4 py-3 align-top'>
+                  {(() => {
+                    const key = row._statusKey || 'on_track';
+                    const style = STATUS_KEY_BADGE[key] || STATUS_KEY_BADGE['on_track'];
+                    return (
+                      <span className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-full text-xs font-semibold ${style.bg} ${style.text}`}>
+                        <span className={`w-1.5 h-1.5 rounded-full ${style.dot}`} />
+                        {row[UI_PROJECT_KEYS.STATUS] || '—'}
+                      </span>
+                    );
+                  })()}
                 </td>
                 <td className='px-4 py-3 align-top bg-white/50 dark:bg-slate-800/50 group-hover:bg-transparent'>
                   <input

--- a/dashboard/src/components/pmo_dashboard/EditableTable.tsx
+++ b/dashboard/src/components/pmo_dashboard/EditableTable.tsx
@@ -53,12 +53,11 @@ const EditableTable: React.FC<EditableTableProps> = ({
               <th className='px-4 py-3 w-[10%]'>Project Manager</th>
               <th className='px-4 py-3 w-[9%]'>Due Date</th>
               <th className='px-4 py-3 w-[10%]'>Status</th>
-              <th className='px-4 py-3 w-[9%]'>Budget (Hrs)</th>
-              <th className='px-4 py-3 w-[9%]'>Consumed (Hrs)</th>
-              <th className='px-4 py-3 w-[11%]'>Sales (ZAR)</th>
-              <th className='px-4 py-3 w-[11%]'>Cost (ZAR)</th>
-              <th className='px-4 py-3 w-[9%]'>Progress</th>
-              <th className='px-2 py-3 w-[4%] print:hidden'></th>
+              <th className='px-4 py-3 w-[9%] text-right'>Budget (Hrs)</th>
+              <th className='px-4 py-3 w-[9%] text-right'>Consumed (Hrs)</th>
+              <th className='px-4 py-3 w-[11%] text-right'>Sales (ZAR)</th>
+              <th className='px-4 py-3 w-[11%] text-right'>Cost (ZAR)</th>
+              <th className='px-4 py-3 w-[9%] text-right'>Progress</th>
             </tr>
           </thead>
           <tbody className='divide-y divide-slate-100'>
@@ -92,27 +91,17 @@ const EditableTable: React.FC<EditableTableProps> = ({
                     const style = STATUS_KEY_BADGE[key] || STATUS_KEY_BADGE['on_track'];
                     return (
                       <span className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-full text-xs font-semibold ${style.bg} ${style.text}`}>
-                        <span className={`w-1.5 h-1.5 rounded-full ${style.dot}`} />
+                        <span className={`w-2.5 h-2.5 rounded-full ${style.dot}`} />
                         {row[UI_PROJECT_KEYS.STATUS] || '—'}
                       </span>
                     );
                   })()}
                 </td>
-                <td className='px-4 py-3 align-top bg-white/50 dark:bg-slate-800/50 group-hover:bg-transparent'>
-                  <input
-                    type='number'
-                    value={row[UI_PROJECT_KEYS.BUDGET_HOURS] || 0}
-                    onChange={(e) => handleChange(row._id, UI_PROJECT_KEYS.BUDGET_HOURS, e.target.value, 'number')}
-                    className='w-full bg-transparent border-b border-transparent focus:border-indigo-400 focus:bg-white dark:focus:bg-slate-700 px-2 py-1 outline-none text-sm text-slate-600 dark:text-slate-300 transition-all'
-                  />
+                <td className='px-4 py-3 align-top text-right text-sm text-slate-600 dark:text-slate-300'>
+                  {formatNumberInt(row[UI_PROJECT_KEYS.BUDGET_HOURS] || 0)}
                 </td>
-                <td className='px-4 py-3 align-top bg-white/50 dark:bg-slate-800/50 group-hover:bg-transparent'>
-                  <input
-                    type='number'
-                    value={row[UI_PROJECT_KEYS.CONSUMED_TIME].toFixed(2) || 0}
-                    onChange={(e) => handleChange(row._id, UI_PROJECT_KEYS.CONSUMED_TIME, e.target.value, 'number')}
-                    className='w-full bg-transparent border-b border-transparent focus:border-indigo-400 focus:bg-white dark:focus:bg-slate-700 px-2 py-1 outline-none text-sm text-slate-600 dark:text-slate-300 transition-all cursor-text'
-                  />
+                <td className='px-4 py-3 align-top text-right text-sm text-slate-600 dark:text-slate-300'>
+                  {row[UI_PROJECT_KEYS.CONSUMED_TIME].toFixed(2)}
                 </td>
                 <td className='px-4 py-3 align-top bg-white/50 dark:bg-slate-800/50 group-hover:bg-transparent'>
                   <input
@@ -122,7 +111,7 @@ const EditableTable: React.FC<EditableTableProps> = ({
                       const val = e.target.value.replace(/,/g, '');
                       handleChange(row._id, UI_PROJECT_KEYS.TOTAL_SALES_AMOUNT, val, 'number');
                     }}
-                    className='w-full bg-transparent border-b border-transparent focus:border-emerald-400 focus:bg-white dark:focus:bg-slate-700 px-2 py-1 outline-none text-sm text-emerald-600 font-medium transition-all text-right'
+                    className='w-full bg-transparent border-b border-transparent focus:border-emerald-400 focus:bg-white dark:focus:bg-slate-700 outline-none text-sm text-emerald-600 font-medium transition-all text-right'
                   />
                 </td>
                 <td className='px-4 py-3 align-top bg-white/50 dark:bg-slate-800/50 group-hover:bg-transparent'>
@@ -133,29 +122,11 @@ const EditableTable: React.FC<EditableTableProps> = ({
                       const val = e.target.value.replace(/,/g, '');
                       handleChange(row._id, UI_PROJECT_KEYS.TOTAL_COSTING, val, 'number');
                     }}
-                    className='w-full bg-transparent border-b border-transparent focus:border-rose-400 focus:bg-white dark:focus:bg-slate-700 px-2 py-1 outline-none text-sm text-rose-600 font-medium transition-all text-right'
+                    className='w-full bg-transparent border-b border-transparent focus:border-rose-400 focus:bg-white dark:focus:bg-slate-700 outline-none text-sm text-rose-600 font-medium transition-all text-right'
                   />
                 </td>
-                <td className='px-4 py-3 align-top bg-white/50 dark:bg-slate-800/50 group-hover:bg-transparent'>
-                  <div className='flex items-center gap-1'>
-                    <input
-                      type='number'
-                      step='1'
-                      value={Math.round((row[UI_PROJECT_KEYS.ACTUAL_PROGRESS] || 0) * 100)}
-                      onChange={(e) => handleChange(row._id, UI_PROJECT_KEYS.ACTUAL_PROGRESS, String((parseFloat(e.target.value) || 0) / 100), 'number')}
-                      className='w-full bg-transparent border-b border-transparent focus:border-indigo-400 focus:bg-white dark:focus:bg-slate-700 px-2 py-1 outline-none text-sm text-slate-600 dark:text-slate-300 font-bold transition-all text-right'
-                    />
-                    <span className='text-slate-500 font-bold'>%</span>
-                  </div>
-                </td>
-                <td className='px-2 py-3 align-top text-center print:hidden'>
-                  <button
-                    onClick={() => void onDeleteDataRow(row._id)}
-                    className='p-2 text-slate-300 hover:text-rose-500 hover:bg-rose-50 rounded-lg transition-colors inline-flex items-center justify-center opacity-30 group-hover:opacity-100'
-                    title='Delete Project'
-                  >
-                    <Trash2 size={16} />
-                  </button>
+                <td className='px-4 py-3 align-top text-right text-sm text-slate-600 dark:text-slate-300 font-bold'>
+                  {Math.round((row[UI_PROJECT_KEYS.ACTUAL_PROGRESS] || 0) * 100)}%
                 </td>
               </tr>
             ))}

--- a/dashboard/src/components/pmo_dashboard/GanttView.tsx
+++ b/dashboard/src/components/pmo_dashboard/GanttView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Gantt, Task, ViewMode } from 'gantt-task-react';
 import 'gantt-task-react/dist/index.css';
 import { Maximize2, Minimize2 } from 'lucide-react';
@@ -22,8 +22,11 @@ const CustomTooltip = ({ task, fontSize, fontFamily }: any) => {
   );
 };
 
+const COLUMN_WIDTH = 60;
+
 const GanttView: React.FC<GanttViewProps> = ({ data, onViewDetails }) => {
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
 
   const tasks = useMemo<Task[]>(() => {
     return data.map((proj) => {
@@ -56,6 +59,27 @@ const GanttView: React.FC<GanttViewProps> = ({ data, onViewDetails }) => {
     });
   }, [data]);
 
+  useEffect(() => {
+    if (!wrapperRef.current || tasks.length === 0) return;
+    const minDate = new Date(Math.min(...tasks.map((t) => t.start.getTime())));
+    const today = new Date();
+    const monthsDiff =
+      (today.getFullYear() - minDate.getFullYear()) * 12 +
+      (today.getMonth() - minDate.getMonth());
+    const scrollTarget = Math.max(0, (monthsDiff - 2) * COLUMN_WIDTH);
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (!wrapperRef.current) return;
+        wrapperRef.current.querySelectorAll<HTMLElement>('*').forEach((el) => {
+          const { overflowX } = window.getComputedStyle(el);
+          if ((overflowX === 'auto' || overflowX === 'scroll') && el.scrollWidth > el.clientWidth) {
+            el.scrollLeft = scrollTarget;
+          }
+        });
+      });
+    });
+  }, [tasks]);
+
   if (tasks.length === 0) {
     return <div className='text-center py-10 text-slate-500'>No projects to display in Gantt View.</div>;
   }
@@ -73,7 +97,7 @@ const GanttView: React.FC<GanttViewProps> = ({ data, onViewDetails }) => {
       {isFullscreen && (
         <div className='fixed inset-0 z-[200] bg-slate-900/60 backdrop-blur-sm transition-opacity duration-300' onClick={() => setIsFullscreen(false)} />
       )}
-      <div className={`bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 shadow-sm gantt-wrapper custom-scrollbar transition-all duration-300 flex flex-col ${isFullscreen ? 'fixed inset-4 z-[201] shadow-2xl' : 'relative overflow-x-auto overflow-y-hidden'}`}>
+      <div ref={wrapperRef} className={`bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 shadow-sm gantt-wrapper custom-scrollbar transition-all duration-300 flex flex-col ${isFullscreen ? 'fixed inset-4 z-[201] shadow-2xl' : 'relative overflow-x-auto overflow-y-hidden'}`}>
         <style>{`
           .dark .gantt-wrapper svg text { fill: #cbd5e1 !important; }
           .dark .gantt-wrapper svg line, .dark .gantt-wrapper svg path, .dark .gantt-wrapper svg polygon { stroke: #334155 !important; }
@@ -97,7 +121,7 @@ const GanttView: React.FC<GanttViewProps> = ({ data, onViewDetails }) => {
             viewMode={ViewMode.Month}
             onClick={handleTaskClick}
             listCellWidth='180px'
-            columnWidth={60}
+            columnWidth={COLUMN_WIDTH}
             fontFamily="'Outfit', 'Inter', sans-serif"
             fontSize='12px'
             rowHeight={45}

--- a/dashboard/src/components/pmo_dashboard/StatusChart.tsx
+++ b/dashboard/src/components/pmo_dashboard/StatusChart.tsx
@@ -8,27 +8,29 @@ type StatusChartProps = {
 };
 
 const STATUS_COLORS: Record<string, string> = {
-  '🟢 On track': '#10B981',
-  '🟡 Warning': '#EAB308',
-  '🟡 Delayed': '#EAB308',
-  '🔴 At risk': '#EF4444',
-  '🔵 Overdue': '#3B82F6',
-  '⚪ On Hold': '#94A3B8',
-  '🟣 Completed': '#7C3AED',
+  on_track:  '#10B981',
+  warning:   '#EAB308',
+  at_risk:   '#EF4444',
+  overdue:   '#3B82F6',
+  on_hold:   '#94A3B8',
+  completed: '#7C3AED',
 };
 
 const FALLBACK_COLORS = ['#8B5CF6', '#64748B', '#06B6D4', '#F43F5E'];
 
 const StatusChart: React.FC<StatusChartProps> = ({ data, onStatusClick }) => {
-  const statusCounts: Record<string, number> = {};
+  const statusGroups: Record<string, { label: string; count: number }> = {};
   data.forEach((d) => {
-    const status = d.Status || 'Undefined';
-    statusCounts[status] = (statusCounts[status] || 0) + 1;
+    const key = d._statusKey || 'on_track';
+    const label = d.Status || key;
+    if (!statusGroups[key]) statusGroups[key] = { label, count: 0 };
+    statusGroups[key].count++;
   });
 
-  const chartData = Object.keys(statusCounts).map((key) => ({
-    name: key,
-    value: statusCounts[key],
+  const chartData = Object.entries(statusGroups).map(([key, { label, count }]) => ({
+    name: label,
+    statusKey: key,
+    value: count,
   }));
 
   return (
@@ -49,7 +51,7 @@ const StatusChart: React.FC<StatusChartProps> = ({ data, onStatusClick }) => {
             {chartData.map((entry, index) => (
               <Cell
                 key={`cell-${index}`}
-                fill={STATUS_COLORS[entry.name] || FALLBACK_COLORS[index % FALLBACK_COLORS.length]}
+                fill={STATUS_COLORS[entry.statusKey] || FALLBACK_COLORS[index % FALLBACK_COLORS.length]}
                 style={{ outline: 'none' }}
               />
             ))}
@@ -59,7 +61,6 @@ const StatusChart: React.FC<StatusChartProps> = ({ data, onStatusClick }) => {
             verticalAlign='bottom'
             height={36}
             iconType='circle'
-            formatter={(value: string) => value.split(' ').slice(1).join(' ')}
             wrapperStyle={{ fontSize: '13px', fontWeight: 500, cursor: 'pointer' }}
             onClick={(entry: any) => onStatusClick && onStatusClick(entry.value)}
           />

--- a/dashboard/src/constants/pmo_dashboard.ts
+++ b/dashboard/src/constants/pmo_dashboard.ts
@@ -16,6 +16,17 @@ export const UI_PROJECT_KEYS = {
   SUBTASKS: 'SubTasks',
 } as const;
 
+export const STATUS_KEY_BADGE: Record<string, { bg: string; text: string; dot: string }> = {
+  on_track:  { bg: 'bg-emerald-50 dark:bg-emerald-900/20',  text: 'text-emerald-700 dark:text-emerald-400', dot: 'bg-emerald-500' },
+  warning:   { bg: 'bg-amber-50 dark:bg-amber-900/20',     text: 'text-amber-700 dark:text-amber-400',    dot: 'bg-amber-400' },
+  at_risk:   { bg: 'bg-rose-50 dark:bg-rose-900/20',       text: 'text-rose-700 dark:text-rose-400',      dot: 'bg-rose-500' },
+  overdue:   { bg: 'bg-blue-50 dark:bg-blue-900/20',       text: 'text-blue-700 dark:text-blue-400',      dot: 'bg-blue-500' },
+  on_hold:   { bg: 'bg-slate-100 dark:bg-slate-800',       text: 'text-slate-500 dark:text-slate-400',    dot: 'bg-slate-400' },
+  completed: { bg: 'bg-violet-50 dark:bg-violet-900/20',   text: 'text-violet-700 dark:text-violet-400',  dot: 'bg-violet-500' },
+};
+
+export const AT_RISK_STATUS_KEYS = new Set(['at_risk', 'overdue', 'warning']);
+
 export const API_STATUS_TO_UI_STATUS: Record<string, string> = {
   on_track: '🟢 On track',
   warning: '🟡 Warning',

--- a/dashboard/src/services/pmo_dashboard/api.ts
+++ b/dashboard/src/services/pmo_dashboard/api.ts
@@ -39,6 +39,7 @@ const UI_PROJECT_MAPPERS: Record<keyof UIProjectRow, (project: ApiProject) => UI
   [UI_PROJECT_KEYS.BUSINESS_UNIT]: (project) => project.business_unit || 'General',
   [UI_PROJECT_KEYS.SUBTASKS]: (project) => (project.subtasks || []).map(mapSubTask),
   _statusKey: (project) => project.status,
+  _statusReasons: (project) => project.status_reasons || [],
   _riskReason: () => undefined,
 };
 

--- a/dashboard/src/services/pmo_dashboard/api.ts
+++ b/dashboard/src/services/pmo_dashboard/api.ts
@@ -38,6 +38,7 @@ const UI_PROJECT_MAPPERS: Record<keyof UIProjectRow, (project: ApiProject) => UI
   [UI_PROJECT_KEYS.ACTUAL_PROGRESS]: (project) => project.actual_progress || 0,
   [UI_PROJECT_KEYS.BUSINESS_UNIT]: (project) => project.business_unit || 'General',
   [UI_PROJECT_KEYS.SUBTASKS]: (project) => (project.subtasks || []).map(mapSubTask),
+  _statusKey: (project) => project.status,
   _riskReason: () => undefined,
 };
 

--- a/dashboard/src/types/pmo_dashboard.ts
+++ b/dashboard/src/types/pmo_dashboard.ts
@@ -69,6 +69,7 @@ export type UIProjectRow = {
   [UI_PROJECT_KEYS.ACTUAL_PROGRESS]: number;
   [UI_PROJECT_KEYS.BUSINESS_UNIT]: string;
   [UI_PROJECT_KEYS.SUBTASKS]: UISubTask[];
+  _statusKey?: string;
   _riskReason?: RiskReason[];
 };
 

--- a/dashboard/src/types/pmo_dashboard.ts
+++ b/dashboard/src/types/pmo_dashboard.ts
@@ -23,6 +23,7 @@ export type ApiProject = {
   project_type?: string | null;
   status: string;
   status_label?: string | null;
+  status_reasons?: string[];
   rag: string | null;
   business_unit: string | null;
   due_date: string | null;
@@ -70,6 +71,7 @@ export type UIProjectRow = {
   [UI_PROJECT_KEYS.BUSINESS_UNIT]: string;
   [UI_PROJECT_KEYS.SUBTASKS]: UISubTask[];
   _statusKey?: string;
+  _statusReasons?: string[];
   _riskReason?: RiskReason[];
 };
 

--- a/dashboard/tailwind.config.js
+++ b/dashboard/tailwind.config.js
@@ -1,5 +1,9 @@
 module.exports = {
-  content: ['./src/components/pmo_dashboard/**/*.{js,jsx,ts,tsx}', './src/PMODashboard.tsx'],
+  content: [
+    './src/components/pmo_dashboard/**/*.{js,jsx,ts,tsx}',
+    './src/constants/**/*.{js,jsx,ts,tsx}',
+    './src/PMODashboard.tsx',
+  ],
   darkMode: 'class',
   theme: {
     extend: {

--- a/pmo_dashboard/serializers/project.py
+++ b/pmo_dashboard/serializers/project.py
@@ -2,7 +2,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from pmo_dashboard.status_rules import evaluate_status, get_status_label
+from pmo_dashboard.status_rules import evaluate_status, get_status_label, get_status_reasons
 from timesheet.models.project import Project
 from timesheet.models.task import Task
 
@@ -42,6 +42,7 @@ class ProjectSerializer(serializers.ModelSerializer):
     customer = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField()
     status_label = serializers.SerializerMethodField()
+    status_reasons = serializers.SerializerMethodField()
     rag = serializers.SerializerMethodField()
     start_date = serializers.DateField(source='expected_start_date')
     due_date = serializers.DateField(source='expected_end_date')
@@ -58,7 +59,7 @@ class ProjectSerializer(serializers.ModelSerializer):
         model = Project
         fields = [
             'id', 'name', 'business_unit', 'project_type', 'customer',
-            'status', 'status_label', 'rag', 'start_date', 'due_date',
+            'status', 'status_label', 'status_reasons', 'rag', 'start_date', 'due_date',
             'project_manager', 'relations_manager',
             'budget_hours', 'consumed_time', 'progress_in_hours',
             'actual_progress', 'estimated_costing', 'total_sales_amount',
@@ -82,6 +83,10 @@ class ProjectSerializer(serializers.ModelSerializer):
     @extend_schema_field(OpenApiTypes.STR)
     def get_status_label(self, obj):
         return get_status_label(evaluate_status(obj))
+
+    @extend_schema_field({'type': 'array', 'items': {'type': 'string'}})
+    def get_status_reasons(self, obj):
+        return get_status_reasons(obj)
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_rag(self, obj):

--- a/pmo_dashboard/status_rules.py
+++ b/pmo_dashboard/status_rules.py
@@ -105,6 +105,57 @@ def _matches_condition(facts, condition):
     return _compare(facts.get(field), op, value)
 
 
+def _collect_ratio_thresholds(config):
+    """Walk all rule conditions and collect gte/gt thresholds for numeric ratio fields."""
+    thresholds = {}
+
+    def walk(condition):
+        if 'all' in condition:
+            for child in condition['all']:
+                walk(child)
+        elif 'any' in condition:
+            for child in condition['any']:
+                walk(child)
+        else:
+            field = condition.get('field')
+            op = condition.get('op')
+            value = condition.get('value')
+            if field and op in ('gte', 'gt') and isinstance(value, (int, float)):
+                thresholds.setdefault(field, set()).add(value)
+
+    for rule in config['rules']:
+        walk(rule['when'])
+    return thresholds
+
+
+def get_status_reasons(project):
+    """Return a list of human-readable reason strings explaining why a project has its status."""
+    config = get_effective_status_config()
+    facts = build_project_facts(project)
+    thresholds = _collect_ratio_thresholds(config)
+    reasons = []
+
+    if facts.get('behind_schedule'):
+        reasons.append('Behind Schedule')
+
+    if facts.get('over_budget'):
+        reasons.append('Budget Overrun')
+    else:
+        hours_ratio = facts.get('hours_ratio')
+        if hours_ratio is not None:
+            crossed = sorted(t for t in thresholds.get('hours_ratio', []) if hours_ratio >= t)
+            if crossed:
+                reasons.append(f'Hours at {int(crossed[0] * 100)}%+')
+
+    cost_ratio = facts.get('cost_ratio')
+    if cost_ratio is not None:
+        crossed = sorted(t for t in thresholds.get('cost_ratio', []) if cost_ratio >= t)
+        if crossed:
+            reasons.append(f'Cost at {int(crossed[0] * 100)}%+')
+
+    return reasons
+
+
 def evaluate_status(project):
     config = get_effective_status_config()
     facts = build_project_facts(project)

--- a/pmo_dashboard/tests.py
+++ b/pmo_dashboard/tests.py
@@ -29,6 +29,7 @@ class TestProjectListView(TestCase):
         self.prefs = preferences.TimesheetPreferences
         self.prefs.pmo_status_config = deepcopy(self.default_status_config)
         self.prefs.save()
+        self.prefs.pmo_allowed_groups.add(pmo_group)
 
     def tearDown(self):
         self.prefs.pmo_status_config = deepcopy(self.default_status_config)
@@ -63,6 +64,7 @@ class TestProjectListView(TestCase):
 
     def test_administrators_group_user_can_access_dashboard_and_api(self):
         admin_group, _ = Group.objects.get_or_create(name='Administrators')
+        self.prefs.pmo_allowed_groups.add(admin_group)
         admin_user = User.objects.create_user(username='admin_group_user', password='pass')
         admin_user.groups.add(admin_group)
 
@@ -154,10 +156,10 @@ class TestProjectListView(TestCase):
         self.assertEqual(p['gross_margin'], 4000.0)
         self.assertAlmostEqual(p['per_gross_margin'], 33.33, places=2)
 
-    def test_inactive_project_status_is_completed(self):
+    def test_inactive_project_not_returned_by_api(self):
+        # The API filters to is_active=True, so inactive/completed projects are excluded.
         Project.objects.create(name='Done', is_active=False)
-        p = self.client.get(self.url).json()[0]
-        self.assertEqual(p['status'], 'completed')
+        self.assertEqual(self.client.get(self.url).json(), [])
 
     def test_warning_status_when_consumed_hours_hit_90_percent(self):
         project = Project.objects.create(


### PR DESCRIPTION
This is PR for https://github.com/kartoza/timesheet-project/issues/231

**Status column and At Risk panel are now using calculation from preference**
<img width="1033" height="621" alt="Screenshot_20260604_133349" src="https://github.com/user-attachments/assets/bfbcb2ac-5067-43a4-9003-f8a1718a6403" />
<img width="1186" height="692" alt="Screenshot_20260604_133415" src="https://github.com/user-attachments/assets/c88540de-4cf6-4447-bae5-6b31b1121dcb" />

**Gantt chart will now jump to today's date when opened**
<img width="1482" height="781" alt="Screenshot_20260604_134648" src="https://github.com/user-attachments/assets/e700aafb-b188-4ab8-a091-a4026e377f1f" />

**Fix text in Kartoza Portofolio Health**
<img width="873" height="479" alt="Screenshot_20260604_135514" src="https://github.com/user-attachments/assets/38bab45b-e52e-4038-9b62-61fbd684d1f9" />
