### PR TITLE
Show team members' names not Emails

### DIFF
--- a/dashboard/src/utils/pmo_dashboard.ts
+++ b/dashboard/src/utils/pmo_dashboard.ts
@@ -1,6 +1,30 @@
+function toDisplayName(value: string): string {
+  return value
+    .split(/[._-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(' ');
+}
+
 export function formatManagerName(name: string): string {
-  const cleaned = name.replace('@kartoza.com', '');
-  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+  const trimmed = (name || '').trim();
+  if (!trimmed) return '';
+
+  const lower = trimmed.toLowerCase();
+  const emailMatch = lower.match(/^([^@\s]+)@([^@\s]+)$/);
+
+  if (emailMatch) {
+    const localPart = emailMatch[1];
+    const domain = emailMatch[2];
+
+    if (domain.startsWith('kartoza')) {
+      return toDisplayName(localPart);
+    }
+
+    return `${localPart}@${domain}`;
+  }
+
+  return toDisplayName(trimmed);
 }
 
 export function timeAgo(iso: string): string {


### PR DESCRIPTION
Fixes #270

Before:

<img width="410" height="159" alt="Screenshot From 2026-06-19 10-40-22" src="https://github.com/user-attachments/assets/905d0024-67b5-4753-95b8-8cc97e6281a8" />

After:
<img width="746" height="166" alt="Screenshot From 2026-06-19 10-42-55" src="https://github.com/user-attachments/assets/30e5758a-d1db-4fd1-8370-c769c7adbb45" />
